### PR TITLE
Implement GPX upload support

### DIFF
--- a/app/api/gpx-upload/route.ts
+++ b/app/api/gpx-upload/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server"
+import { db, sql } from "@/db"
+import gpxParse from "gpx-parse/lib/gpx-parse"
+
+const parseGpx = (text: string) =>
+  new Promise<any>((resolve, reject) => {
+    gpxParse.parseGpx(text, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
+  })
+
+export async function POST(request: Request) {
+  try {
+    const formData = await request.formData()
+    const file = formData.get("file")
+    const force = formData.get("force") === "true"
+
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: "Arquivo não enviado" }, { status: 400 })
+    }
+
+    const text = await file.text()
+    const data = await parseGpx(text)
+
+    if (!data.tracks || data.tracks.length === 0) {
+      return NextResponse.json({ error: "Arquivo GPX não contém trilha" }, { status: 400 })
+    }
+
+    if ((!data.waypoints || data.waypoints.length === 0) && !force) {
+      return NextResponse.json({ error: "no_waypoints" }, { status: 400 })
+    }
+
+    const points = data.tracks[0].segments.flat()
+    const linestring = `LINESTRING(${points.map((p: any) => `${p.lon} ${p.lat}`).join(",")})`
+    const firstTime = points[0]?.time ? new Date(points[0].time).toISOString() : null
+    const baseName = file.name.replace(/\.gpx$/i, "")
+    const nome = firstTime ? `${baseName}-${firstTime.split("T")[0]}` : baseName
+
+    const trilhaResult = await db.execute(sql`
+      INSERT INTO rio_da_prata.trilhas (nome, geom, data)
+      VALUES (${nome}, ST_SetSRID(ST_GeomFromText(${linestring}), 4326), ${firstTime})
+      RETURNING id
+    `)
+
+    const trilhaId = trilhaResult.rows[0].id
+
+    if (data.waypoints && data.waypoints.length > 0) {
+      for (const w of data.waypoints) {
+        const time = w.time ? new Date(w.time).toISOString() : null
+        await db.execute(sql`
+          INSERT INTO rio_da_prata.waypoints (trilha_id, nome, geom, ele, recorded_at)
+          VALUES (
+            ${trilhaId},
+            ${w.name ?? null},
+            ST_SetSRID(ST_MakePoint(${w.lon}, ${w.lat}), 4326),
+            ${w.elevation ?? null},
+            ${time}
+          )
+        `)
+      }
+    }
+
+    return NextResponse.json({ success: true, trilhaId })
+  } catch (err) {
+    console.error("Erro ao processar GPX:", err)
+    return NextResponse.json({ error: "Erro no servidor" }, { status: 500 })
+  }
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -31,9 +31,14 @@ export function Navbar() {
     await supabase.auth.signOut()
   }
 
-  const handleGpxUpload = (file: File) => {
-    console.log("Arquivo GPX para upload:", file)
-    // Implemente sua lógica de upload aqui
+  const handleGpxUpload = async (file: File) => {
+    const formData = new FormData()
+    formData.append("file", file)
+    const res = await fetch("/api/gpx-upload", { method: "POST", body: formData })
+    if (!res.ok) {
+      const data = await res.json().catch(() => null)
+      console.error("Falha no upload GPX", data)
+    }
   }
 
   // Only show nav items after role check is complete

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -437,10 +437,28 @@ export const baciaRioDaPrataInRioDaPrata = rioDaPrata.table("Bacia_Rio_Da_Prata"
 
 
 export const expedicoes = rioDaPrata.table("trilha_e_waypoints", {
-	id: serial().primaryKey().notNull(),
-	tipo: text().notNull(), // 'trilha' ou 'waypoint'
-	name: text(),           // nome do waypoint (ex: "Jacaré")
-	recordedAt: timestamp({ mode: 'string' }),
-	ele: doublePrecision(),
-	geom: geometry({ type: "geometry", srid: 4326 }), // pode ser LineString ou Point
+        id: serial().primaryKey().notNull(),
+        tipo: text().notNull(), // 'trilha' ou 'waypoint'
+        name: text(),           // nome do waypoint (ex: "Jacaré")
+        recordedAt: timestamp({ mode: 'string' }),
+        ele: doublePrecision(),
+        geom: geometry({ type: "geometry", srid: 4326 }), // pode ser LineString ou Point
   });
+
+export const trilhas = rioDaPrata.table("trilhas", {
+        id: serial().primaryKey().notNull(),
+        nome: text().notNull(),
+        geom: geometry({ type: "linestring", srid: 4326 }).notNull(),
+        data: timestamp({ mode: 'string' }),
+});
+
+export const waypoints = rioDaPrata.table("waypoints", {
+        id: serial().primaryKey().notNull(),
+        trilhaId: integer("trilha_id")
+                .references(() => trilhas.id, { onDelete: "cascade" })
+                .notNull(),
+        nome: text(),
+        geom: geometry({ type: "point", srid: 4326 }).notNull(),
+        ele: doublePrecision(),
+        recordedAt: timestamp({ mode: 'string' }),
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "dotenv": "^16.4.7",
         "drizzle-orm": "^0.39.2",
         "framer-motion": "^12.0.6",
+        "gpx-parse": "^0.10.4",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.468.0",
         "next": "latest",
@@ -4382,6 +4383,15 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/gpx-parse": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/gpx-parse/-/gpx-parse-0.10.4.tgz",
+      "integrity": "sha512-4PUA2Hzp4m5EjDEa4YB1CKWh5Cjm1cgJuDe+nL6B77DgtFuYR7VtvBbmvbwjx6M40iA96q2BaKyD8/lraez2xw==",
+      "license": "MIT",
+      "dependencies": {
+        "xml2js": "^0.4.4"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -5516,6 +5526,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/scheduler": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
@@ -6616,6 +6632,28 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dotenv": "^16.4.7",
     "drizzle-orm": "^0.39.2",
     "framer-motion": "^12.0.6",
+    "gpx-parse": "^0.10.4",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.468.0",
     "next": "latest",


### PR DESCRIPTION
## Summary
- add API endpoint to parse GPX files and insert new `trilhas` and `waypoints`
- support GPX uploads in the admin navbar and upload modal
- include `gpx-parse` dependency
- define new `trilhas` and `waypoints` tables in schema

## Testing
- `npm run build` *(fails: unable to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685094547c948320aa15282bba22f960