### PR TITLE
Add expeditions layer to map

### DIFF
--- a/app/api/map/expedicoes/route.ts
+++ b/app/api/map/expedicoes/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server"
+import { db } from "@/db"
+
+export async function GET() {
+  try {
+    const [trilhas, waypoints] = await Promise.all([
+      db.execute(`
+        SELECT id, nome, data_inicio, data_fim, duracao_minutos, ST_AsGeoJSON(geom) as geojson
+        FROM "rio_da_prata"."trilhas"
+      `),
+      db.execute(`
+        SELECT w.id, w.trilha_id, w.nome, w.ele, w.recordedat, t.nome as trilha_nome, ST_AsGeoJSON(w.geom) as geojson
+        FROM "rio_da_prata"."waypoints" w
+        JOIN "rio_da_prata"."trilhas" t ON w.trilha_id = t.id
+      `),
+    ])
+
+    const trilhasGeoJSON = {
+      type: "FeatureCollection",
+      features: trilhas.rows.map((row: any) => ({
+        type: "Feature",
+        properties: {
+          id: row.id,
+          expedicao: row.nome,
+          data: row.data_inicio,
+          data_fim: row.data_fim,
+          duracao: row.duracao_minutos,
+        },
+        geometry: JSON.parse(row.geojson),
+      })),
+    }
+
+    const waypointsGeoJSON = {
+      type: "FeatureCollection",
+      features: waypoints.rows.map((row: any) => ({
+        type: "Feature",
+        properties: {
+          id: row.id,
+          trilhaId: row.trilha_id,
+          expedicao: row.trilha_nome,
+          name: row.nome,
+          ele: row.ele,
+          data: row.recordedat,
+        },
+        geometry: JSON.parse(row.geojson),
+      })),
+    }
+
+    return NextResponse.json({ trilhas: trilhasGeoJSON, waypoints: waypointsGeoJSON })
+  } catch (error) {
+    console.error("Erro ao buscar expedições:", error)
+    return NextResponse.json({ error: "Falha ao obter os dados de expedições" }, { status: 500 })
+  }
+}

--- a/components/map/map.tsx
+++ b/components/map/map.tsx
@@ -1,33 +1,61 @@
-"use client"
+"use client";
 
-import { useEffect, useState, useMemo } from "react"
-import dynamic from "next/dynamic"
-import type { LatLngExpression } from "leaflet"
-import "leaflet/dist/leaflet.css"
-import { CustomZoomControl } from "./CustomZoomControl"
-import { CustomLayerControl } from "./CustomLayerControl"
-import { MapLayersCard } from "./MapLayerCard"
-import { ActionsLayerCard } from "./ActionLayerCard"
-import { DateFilterControl } from "./DateFilterControl"
-import { useMapContext } from "@/context/GeoDataContext"
-import { Home, AlertTriangle, Fish, Anchor, MapPin, Skull, Droplet, Sprout, Ruler, NotebookPen } from "lucide-react"
-import L from "leaflet"
-import ReactDOMServer from "react-dom/server"
-import { Modal } from "./Modal"
-import type React from "react"
-import { Grid } from "@/components/ui/grid"
-import type { Feature, Geometry, GeoJsonProperties } from "geojson"
+import { useEffect, useState, useMemo } from "react";
+import dynamic from "next/dynamic";
+import type { LatLngExpression } from "leaflet";
+import "leaflet/dist/leaflet.css";
+import { CustomZoomControl } from "./CustomZoomControl";
+import { CustomLayerControl } from "./CustomLayerControl";
+import { MapLayersCard } from "./MapLayerCard";
+import { ActionsLayerCard } from "./ActionLayerCard";
+import { DateFilterControl } from "./DateFilterControl";
+import { useMapContext } from "@/context/GeoDataContext";
+import {
+  Home,
+  AlertTriangle,
+  Fish,
+  Anchor,
+  MapPin,
+  Skull,
+  Droplet,
+  Sprout,
+  Ruler,
+  NotebookPen,
+} from "lucide-react";
+import L from "leaflet";
+import ReactDOMServer from "react-dom/server";
+import { Modal } from "./Modal";
+import type React from "react";
+import { Grid } from "@/components/ui/grid";
+import type { Feature, Geometry, GeoJsonProperties } from "geojson";
 
-const MapContainer = dynamic(() => import("react-leaflet").then((mod) => mod.MapContainer), { ssr: false })
-const TileLayer = dynamic(() => import("react-leaflet").then((mod) => mod.TileLayer), { ssr: false })
-const GeoJSON = dynamic(() => import("react-leaflet").then((mod) => mod.GeoJSON), { ssr: false })
-const CircleMarker = dynamic(() => import("react-leaflet").then((mod) => mod.CircleMarker), { ssr: false })
-const Marker = dynamic(() => import("react-leaflet").then((mod) => mod.Marker), { ssr: false })
-const Popup = dynamic(() => import("react-leaflet").then((mod) => mod.Popup), { ssr: false })
+const MapContainer = dynamic(
+  () => import("react-leaflet").then((mod) => mod.MapContainer),
+  { ssr: false },
+);
+const TileLayer = dynamic(
+  () => import("react-leaflet").then((mod) => mod.TileLayer),
+  { ssr: false },
+);
+const GeoJSON = dynamic(
+  () => import("react-leaflet").then((mod) => mod.GeoJSON),
+  { ssr: false },
+);
+const CircleMarker = dynamic(
+  () => import("react-leaflet").then((mod) => mod.CircleMarker),
+  { ssr: false },
+);
+const Marker = dynamic(
+  () => import("react-leaflet").then((mod) => mod.Marker),
+  { ssr: false },
+);
+const Popup = dynamic(() => import("react-leaflet").then((mod) => mod.Popup), {
+  ssr: false,
+});
 
 interface MapProps {
-  center?: LatLngExpression
-  zoom?: number
+  center?: LatLngExpression;
+  zoom?: number;
 }
 
 const layerColors = {
@@ -38,7 +66,8 @@ const layerColors = {
   propriedades: "green",
   firms: "red",
   banhado: "darkblue",
-}
+  expedicoes: "orange",
+};
 
 const actionIcons: { [key: string]: React.ReactNode } = {
   Fazenda: <Home />,
@@ -50,25 +79,34 @@ const actionIcons: { [key: string]: React.ReactNode } = {
   Nascente: <Droplet />,
   Plantio: <Sprout />,
   "Régua Fluvial": <Ruler />,
-}
+};
+
+const waypointIcon = L.divIcon({
+  html: ReactDOMServer.renderToString(<MapPin />),
+  className: "custom-icon",
+  iconSize: [24, 24],
+});
 
 type GeoJSONFeatureCollection = {
-  type: "FeatureCollection"
-  features: Feature<Geometry, GeoJsonProperties>[]
-}
+  type: "FeatureCollection";
+  features: Feature<Geometry, GeoJsonProperties>[];
+};
 
 type MapData = {
-  bacia: GeoJSONFeatureCollection
-  banhado: GeoJSONFeatureCollection
-  propriedades: GeoJSONFeatureCollection
-  leito: GeoJSONFeatureCollection
-  estradas: GeoJSONFeatureCollection
-  desmatamento: GeoJSONFeatureCollection
-  firms: GeoJSONFeatureCollection
-}
+  bacia: GeoJSONFeatureCollection;
+  banhado: GeoJSONFeatureCollection;
+  propriedades: GeoJSONFeatureCollection;
+  leito: GeoJSONFeatureCollection;
+  estradas: GeoJSONFeatureCollection;
+  desmatamento: GeoJSONFeatureCollection;
+  firms: GeoJSONFeatureCollection;
+};
 
-export default function Map({ center = [-21.327773, -56.694734], zoom = 11 }: MapProps) {
-  const [isMounted, setIsMounted] = useState(false)
+export default function Map({
+  center = [-21.327773, -56.694734],
+  zoom = 11,
+}: MapProps) {
+  const [isMounted, setIsMounted] = useState(false);
   const [visibleLayers, setVisibleLayers] = useState<string[]>([
     "estradas",
     "bacia",
@@ -77,71 +115,98 @@ export default function Map({ center = [-21.327773, -56.694734], zoom = 11 }: Ma
     "propriedades",
     "firms",
     "banhado",
-  ])
-  const [visibleActions, setVisibleActions] = useState<string[]>([])
-  const { mapData, actionsData, isLoading, error, modalData, openModal, closeModal, dateFilter, setDateFilter } =
-    useMapContext()
+  ]);
+  const [visibleActions, setVisibleActions] = useState<string[]>([]);
+  const {
+    mapData,
+    actionsData,
+    expedicoesData,
+    isLoading,
+    error,
+    modalData,
+    openModal,
+    closeModal,
+    dateFilter,
+    setDateFilter,
+  } = useMapContext();
 
   useEffect(() => {
-    setIsMounted(true)
-  }, [])
+    setIsMounted(true);
+  }, []);
 
   useEffect(() => {
     //Removed console.log
-  }, [])
+  }, []);
 
   const handleLayerToggle = (id: string, isChecked: boolean) => {
-    setVisibleLayers((prev) => (isChecked ? [...prev, id] : prev.filter((layerId) => layerId !== id)))
-  }
+    setVisibleLayers((prev) =>
+      isChecked ? [...prev, id] : prev.filter((layerId) => layerId !== id),
+    );
+  };
 
   const handleActionToggle = (id: string, isChecked: boolean) => {
-    setVisibleActions((prev) => (isChecked ? [...prev, id] : prev.filter((actionId) => actionId !== id)))
-  }
+    setVisibleActions((prev) =>
+      isChecked ? [...prev, id] : prev.filter((actionId) => actionId !== id),
+    );
+  };
 
   const handleFeatureClick = (properties: any, layerType: string) => {
-    const title = `${layerType.charAt(0).toUpperCase() + layerType.slice(1)} Details`
+    const title = `${layerType.charAt(0).toUpperCase() + layerType.slice(1)} Details`;
     const content = (
       <Grid className="grid-cols-1 md:grid-cols-2 gap-4">
         {Object.entries(properties).map(([key, value]) => (
-          <div key={key} className="bg-gray-100 dark:bg-gray-700 p-3 rounded-md">
-            <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-300 mb-1">{key}</h3>
+          <div
+            key={key}
+            className="bg-gray-100 dark:bg-gray-700 p-3 rounded-md"
+          >
+            <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-300 mb-1">
+              {key}
+            </h3>
             <p className="text-base break-words">{String(value)}</p>
           </div>
         ))}
       </Grid>
-    )
-    openModal(title, content)
-  }
+    );
+    openModal(title, content);
+  };
 
-  const isWithinDateRange = (date: string, startDate: Date | null, endDate: Date | null) => {
-    const itemDate = new Date(date)
-    if (startDate && itemDate < startDate) return false
+  const isWithinDateRange = (
+    date: string,
+    startDate: Date | null,
+    endDate: Date | null,
+  ) => {
+    const itemDate = new Date(date);
+    if (startDate && itemDate < startDate) return false;
     if (endDate) {
-      const adjustedEndDate = new Date(endDate)
-      adjustedEndDate.setHours(23, 59, 59, 999)
-      if (itemDate > adjustedEndDate) return false
+      const adjustedEndDate = new Date(endDate);
+      adjustedEndDate.setHours(23, 59, 59, 999);
+      if (itemDate > adjustedEndDate) return false;
     }
-    return true
-  }
+    return true;
+  };
 
   const filteredDesmatamentoData = useMemo(() => {
     if (mapData && mapData.desmatamento) {
       return {
         type: "FeatureCollection",
         features: mapData.desmatamento.features.filter((feature) =>
-          isWithinDateRange(feature.properties.detectat, dateFilter.startDate, dateFilter.endDate),
+          isWithinDateRange(
+            feature.properties.detectat,
+            dateFilter.startDate,
+            dateFilter.endDate,
+          ),
         ),
-      } as GeoJSONFeatureCollection
+      } as GeoJSONFeatureCollection;
     }
-    return null
-  }, [mapData, dateFilter.startDate, dateFilter.endDate, isWithinDateRange])
+    return null;
+  }, [mapData, dateFilter.startDate, dateFilter.endDate, isWithinDateRange]);
 
   if (!isMounted || isLoading) {
     return (
       <div className="w-screen h-screen bg-gray-100 animate-pulse flex items-center justify-center">
         <span className="text-gray-500">Carregando mapa...</span>
       </div>
-    )
+    );
   }
 
   if (error) {
@@ -149,28 +214,59 @@ export default function Map({ center = [-21.327773, -56.694734], zoom = 11 }: Ma
       <div className="w-screen h-screen bg-gray-100 flex items-center justify-center">
         <span className="text-red-500">Erro ao carregar o mapa: {error}</span>
       </div>
-    )
+    );
   }
 
   const layerOptions = [
-    { id: "bacia", label: "Bacia", count: mapData?.bacia.features.length || 0, color: layerColors.bacia },
-    { id: "banhado", label: "Banhado", count: mapData?.banhado.features.length || 0, color: layerColors.banhado },
+    {
+      id: "bacia",
+      label: "Bacia",
+      count: mapData?.bacia.features.length || 0,
+      color: layerColors.bacia,
+    },
+    {
+      id: "banhado",
+      label: "Banhado",
+      count: mapData?.banhado.features.length || 0,
+      color: layerColors.banhado,
+    },
     {
       id: "propriedades",
       label: "Propriedades",
       count: mapData?.propriedades.features.length || 0,
       color: layerColors.propriedades,
     },
-    { id: "leito", label: "Leito", count: mapData?.leito.features.length || 0, color: layerColors.leito },
-    { id: "estradas", label: "Estradas", count: mapData?.estradas.features.length || 0, color: layerColors.estradas },
+    {
+      id: "leito",
+      label: "Leito",
+      count: mapData?.leito.features.length || 0,
+      color: layerColors.leito,
+    },
+    {
+      id: "estradas",
+      label: "Estradas",
+      count: mapData?.estradas.features.length || 0,
+      color: layerColors.estradas,
+    },
     {
       id: "desmatamento",
       label: "Desmatamento",
       count: mapData?.desmatamento.features.length || 0,
       color: layerColors.desmatamento,
     },
-    { id: "firms", label: "Focos de Incêndio", count: mapData?.firms.features.length || 0, color: layerColors.firms },
-  ]
+    {
+      id: "firms",
+      label: "Focos de Incêndio",
+      count: mapData?.firms.features.length || 0,
+      color: layerColors.firms,
+    },
+    {
+      id: "expedicoes",
+      label: "Expedições",
+      count: expedicoesData?.trilhas.features.length || 0,
+      color: layerColors.expedicoes,
+    },
+  ];
 
   const actionOptions = actionsData
     ? Object.entries(actionsData).map(([acao, data]) => ({
@@ -180,19 +276,24 @@ export default function Map({ center = [-21.327773, -56.694734], zoom = 11 }: Ma
         color: "#FF00FF", // You can assign different colors for different action types
         icon: actionIcons[acao] || <NotebookPen />,
       }))
-    : []
+    : [];
 
   return (
     <div className="w-full h-screen relative z-10">
-      <MapContainer center={center} zoom={zoom} zoomControl={false} className="w-full h-full">
+      <MapContainer
+        center={center}
+        zoom={zoom}
+        zoomControl={false}
+        className="w-full h-full"
+      >
         <TileLayer
           url="https://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}"
           maxZoom={20}
           subdomains={["mt0", "mt1", "mt2", "mt3"]}
           attribution="&copy; Google"
         />
-        <CustomZoomControl  />
-        <CustomLayerControl  />
+        <CustomZoomControl />
+        <CustomLayerControl />
 
         {mapData && visibleLayers.includes("bacia") && (
           <GeoJSON
@@ -207,7 +308,7 @@ export default function Map({ center = [-21.327773, -56.694734], zoom = 11 }: Ma
             onEachFeature={(feature, layer) => {
               layer.on({
                 click: () => handleFeatureClick(feature.properties, "bacia"),
-              })
+              });
             }}
           />
         )}
@@ -224,7 +325,7 @@ export default function Map({ center = [-21.327773, -56.694734], zoom = 11 }: Ma
             onEachFeature={(feature, layer) => {
               layer.on({
                 click: () => handleFeatureClick(feature.properties, "banhado"),
-              })
+              });
             }}
           />
         )}
@@ -240,8 +341,9 @@ export default function Map({ center = [-21.327773, -56.694734], zoom = 11 }: Ma
             })}
             onEachFeature={(feature, layer) => {
               layer.on({
-                click: () => handleFeatureClick(feature.properties, "propriedades"),
-              })
+                click: () =>
+                  handleFeatureClick(feature.properties, "propriedades"),
+              });
             }}
           />
         )}
@@ -256,7 +358,7 @@ export default function Map({ center = [-21.327773, -56.694734], zoom = 11 }: Ma
             onEachFeature={(feature, layer) => {
               layer.on({
                 click: () => handleFeatureClick(feature.properties, "leito"),
-              })
+              });
             }}
           />
         )}
@@ -271,7 +373,7 @@ export default function Map({ center = [-21.327773, -56.694734], zoom = 11 }: Ma
             onEachFeature={(feature, layer) => {
               layer.on({
                 click: () => handleFeatureClick(feature.properties, "estradas"),
-              })
+              });
             }}
           />
         )}
@@ -288,17 +390,24 @@ export default function Map({ center = [-21.327773, -56.694734], zoom = 11 }: Ma
             })}
             onEachFeature={(feature, layer) => {
               layer.on({
-                click: () => handleFeatureClick(feature.properties, "desmatamento"),
-              })
+                click: () =>
+                  handleFeatureClick(feature.properties, "desmatamento"),
+              });
             }}
           />
         )}
         {mapData &&
           visibleLayers.includes("firms") &&
           mapData.firms.features
-            .filter((firm) => isWithinDateRange(firm.properties.acq_date, dateFilter.startDate, dateFilter.endDate))
+            .filter((firm) =>
+              isWithinDateRange(
+                firm.properties.acq_date,
+                dateFilter.startDate,
+                dateFilter.endDate,
+              ),
+            )
             .map((firm, index) => {
-              const coords = firm.geometry.coordinates
+              const coords = firm.geometry.coordinates;
               if (
                 Array.isArray(coords) &&
                 coords.length === 2 &&
@@ -319,17 +428,79 @@ export default function Map({ center = [-21.327773, -56.694734], zoom = 11 }: Ma
                       click: () => handleFeatureClick(firm.properties, "firms"),
                     }}
                   />
-                )
+                );
               }
-              return null
+              return null;
+            })}
+
+        {expedicoesData && visibleLayers.includes("expedicoes") && (
+          <GeoJSON
+            data={
+              {
+                type: "FeatureCollection",
+                features: expedicoesData.trilhas.features.filter((feature) =>
+                  isWithinDateRange(
+                    feature.properties.data,
+                    dateFilter.startDate,
+                    dateFilter.endDate,
+                  ),
+                ),
+              } as any
+            }
+            style={() => ({
+              color: layerColors.expedicoes,
+              weight: 3,
+              opacity: 0.8,
+            })}
+            onEachFeature={(feature, layer) => {
+              layer.on({
+                click: () =>
+                  handleFeatureClick(feature.properties, "expedicoes"),
+              });
+            }}
+          />
+        )}
+
+        {expedicoesData &&
+          visibleLayers.includes("expedicoes") &&
+          expedicoesData.waypoints.features
+            .filter((wp) =>
+              isWithinDateRange(
+                wp.properties.data,
+                dateFilter.startDate,
+                dateFilter.endDate,
+              ),
+            )
+            .map((wp, index) => {
+              const coords = wp.geometry.coordinates as number[];
+              if (Array.isArray(coords) && coords.length >= 2) {
+                return (
+                  <Marker
+                    key={`exp-wp-${index}`}
+                    position={[coords[1], coords[0]]}
+                    icon={waypointIcon}
+                    eventHandlers={{
+                      click: () =>
+                        handleFeatureClick(wp.properties, "expedicoes"),
+                    }}
+                  />
+                );
+              }
+              return null;
             })}
 
         {actionsData &&
           visibleActions.map((actionType) =>
             actionsData[actionType].features
-              .filter((feature) => isWithinDateRange(feature.properties.time, dateFilter.startDate, dateFilter.endDate))
+              .filter((feature) =>
+                isWithinDateRange(
+                  feature.properties.time,
+                  dateFilter.startDate,
+                  dateFilter.endDate,
+                ),
+              )
               .map((feature, index) => {
-                const coords = feature.geometry.coordinates
+                const coords = feature.geometry.coordinates;
                 if (
                   Array.isArray(coords) &&
                   coords.length === 2 &&
@@ -341,17 +512,20 @@ export default function Map({ center = [-21.327773, -56.694734], zoom = 11 }: Ma
                       key={`${actionType}-${index}`}
                       position={[coords[1], coords[0]]}
                       icon={L.divIcon({
-                        html: ReactDOMServer.renderToString(actionIcons[actionType] || <NotebookPen />),
+                        html: ReactDOMServer.renderToString(
+                          actionIcons[actionType] || <NotebookPen />,
+                        ),
                         className: "custom-icon",
                         iconSize: [24, 24],
                       })}
                       eventHandlers={{
-                        click: () => handleFeatureClick(feature.properties, actionType),
+                        click: () =>
+                          handleFeatureClick(feature.properties, actionType),
                       }}
                     ></Marker>
-                  )
+                  );
                 }
-                return null
+                return null;
               }),
           )}
       </MapContainer>
@@ -361,14 +535,25 @@ export default function Map({ center = [-21.327773, -56.694734], zoom = 11 }: Ma
       </div>
 
       <div className="absolute bottom-4 left-4 z-[1000] gap-3 flex flex-col">
-        <MapLayersCard title="Camadas" options={layerOptions} onLayerToggle={handleLayerToggle} />
-        <ActionsLayerCard title="Ações" options={actionOptions} onLayerToggle={handleActionToggle} />
+        <MapLayersCard
+          title="Camadas"
+          options={layerOptions}
+          onLayerToggle={handleLayerToggle}
+        />
+        <ActionsLayerCard
+          title="Ações"
+          options={actionOptions}
+          onLayerToggle={handleActionToggle}
+        />
       </div>
 
-      <Modal isOpen={modalData.isOpen} onClose={closeModal} title={modalData.title}>
+      <Modal
+        isOpen={modalData.isOpen}
+        onClose={closeModal}
+        title={modalData.title}
+      >
         {modalData.content}
       </Modal>
     </div>
-  )
+  );
 }
-

--- a/context/GeoDataContext.tsx
+++ b/context/GeoDataContext.tsx
@@ -29,6 +29,11 @@ type MapData = {
   banhado: GeoJSONFeatureCollection
 }
 
+type ExpedicoesData = {
+  trilhas: GeoJSONFeatureCollection
+  waypoints: GeoJSONFeatureCollection
+}
+
 type ActionsData = {
   [key: string]: GeoJSONFeatureCollection
 }
@@ -42,6 +47,7 @@ type ModalData = {
 type MapContextType = {
   mapData: MapData | null
   actionsData: ActionsData | null
+  expedicoesData: ExpedicoesData | null
   isLoading: boolean
   error: string | null
   modalData: ModalData
@@ -56,6 +62,7 @@ const MapContext = createContext<MapContextType | undefined>(undefined)
 export function MapProvider({ children }: { children: React.ReactNode }) {
   const [mapData, setMapData] = useState<MapData | null>(null)
   const [actionsData, setActionsData] = useState<ActionsData | null>(null)
+  const [expedicoesData, setExpedicoesData] = useState<ExpedicoesData | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [modalData, setModalData] = useState<ModalData>({
@@ -71,6 +78,7 @@ export function MapProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     fetchMapData()
     fetchActionsData()
+    fetchExpedicoesData()
   }, [])
 
   const fetchMapData = async () => {
@@ -102,6 +110,19 @@ export function MapProvider({ children }: { children: React.ReactNode }) {
     }
   }
 
+  const fetchExpedicoesData = async () => {
+    try {
+      const response = await fetch("/api/map/expedicoes")
+      if (!response.ok) {
+        throw new Error("Failed to fetch expeditions data")
+      }
+      const data = await response.json()
+      setExpedicoesData(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An unknown error occurred")
+    }
+  }
+
   const openModal = (title: string, content: React.ReactNode) => {
     setModalData({ isOpen: true, title, content })
   }
@@ -119,6 +140,7 @@ export function MapProvider({ children }: { children: React.ReactNode }) {
       value={{
         mapData,
         actionsData,
+        expedicoesData,
         isLoading,
         error,
         modalData,

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -432,5 +432,23 @@ export const baciaRioDaPrataInRioDaPrata = rioDaPrata.table("Bacia_Rio_Da_Prata"
 	gdpUdSsu: bigint("gdp_ud_ssu", { mode: "number" }),
 	// You can use { mode: "bigint" } if numbers are exceeding js number limitations
 	gdpUdUsu: bigint("gdp_ud_usu", { mode: "number" }),
-	hdiIxSav: integer("hdi_ix_sav"),
+        hdiIxSav: integer("hdi_ix_sav"),
+});
+
+export const trilhas = rioDaPrata.table("trilhas", {
+        id: serial().primaryKey().notNull(),
+        nome: text().notNull(),
+        geom: geometry({ type: "MultiLineStringZ", srid: 4326 }).notNull(),
+        dataInicio: timestamp("data_inicio", { mode: 'string' }),
+        dataFim: timestamp("data_fim", { mode: 'string' }),
+        duracaoMinutos: integer("duracao_minutos"),
+});
+
+export const waypoints = rioDaPrata.table("waypoints", {
+        id: serial().primaryKey().notNull(),
+        trilhaId: integer("trilha_id").references(() => trilhas.id, { onDelete: "cascade" }).notNull(),
+        nome: text(),
+        geom: geometry({ type: "point", srid: 4326 }).notNull(),
+        ele: doublePrecision(),
+        recordedat: timestamp({ mode: 'string' }),
 });


### PR DESCRIPTION
## Summary
- add sample expeditions data and API endpoint
- expose expeditions via `GeoDataContext`
- render expedition tracks and waypoints on the map
- fetch expeditions from database instead of JSON
- fix waypoint display with dedicated marker icon

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6851dd6faf40832096ff9f599f9d0195